### PR TITLE
Relax Colors.jl to 0.9–0.12

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -17,7 +17,7 @@ StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 [compat]
 AutomotiveSimulator = "0.1"
 Cairo = "1.0"
-Colors = "0.11, 0.12"
+Colors = "0.9, 0.10, 0.11, 0.12"
 Parameters = "0.12"
 Reexport = "0.2"
 Rsvg = "1.0"


### PR DESCRIPTION
For compatibility with Flux 0.8, used by POMDPStressTesting.